### PR TITLE
Add fedora support

### DIFF
--- a/provision/install_puppet.sh
+++ b/provision/install_puppet.sh
@@ -133,6 +133,10 @@ ensure_puppet() {
     redhat)
       echo "$OS_DESCRIPTION"
       REPO_URL="https://yum.puppetlabs.com/el/${MAJOR_REV}/products/${MACH}/puppetlabs-release-${MAJOR_REV}-7.noarch.rpm"
+      if lowercase DIST == 'Fedora' ; then
+        REPO_URL="https://yum.puppetlabs.com/fedora/f${MAJOR_REV}/products/${MACH}/puppetlabs-release-${MAJOR_REV}-7.noarch.rpm"
+        ensure_package_present 'gnupg'
+      fi
       # Install GPG key
       if ! rpm -qi gpg-pubkey-4bd6ec30-4ff1e4fa > /dev/null 2>&1 ; then 
         gpg_key=$(mktemp)


### PR DESCRIPTION
Fedora RPMs are maintained under a different URL path pattern in the Puppet Labs repo than RHEL RPMs, as per the examples given at http://docs.puppetlabs.com/guides/puppetlabs_package_repositories.html#for-fedora

As well - at least in Fedora 18 - it was necessary to install the gnupg package; it was not present by default.
