### PR TITLE
Add Fedora support

### DIFF
--- a/provision/install_puppet.sh
+++ b/provision/install_puppet.sh
@@ -133,6 +133,10 @@ ensure_puppet() {
     redhat)
       echo "$OS_DESCRIPTION"
       REPO_URL="https://yum.puppetlabs.com/el/${MAJOR_REV}/products/${MACH}/puppetlabs-release-${MAJOR_REV}-7.noarch.rpm"
+      if lowercase DIST == 'fedora' ; then
+        REPO_URL="https://yum.puppetlabs.com/fedora/f${MAJOR_REV}/products/${MACH}/puppetlabs-release-${MAJOR_REV}-7.noarch.rpm"
+        ensure_package_present 'gnupg'
+      fi
       # Install GPG key
       if ! rpm -qi gpg-pubkey-4bd6ec30-4ff1e4fa > /dev/null 2>&1 ; then 
         gpg_key=$(mktemp)


### PR DESCRIPTION
Fedora RPMs are maintained under a different URL path pattern in the Puppet Labs repo than RHEL RPMs, as per the examples given at http://docs.puppetlabs.com/guides/puppetlabs_package_repositories.html#for-fedora

As well - at least in Fedora 18 - it was necessary to install the gnupg package; it was not present by default.

Output from running the <code>install_puppet.sh</code> script on Fedora 18 after this change:

```
No existing puppet install detected
Preparing to install puppet and facter
Detected redhat-based distro: Fedora Spherical Cow 18 for x86_64
dist
installing gnupg and dependencies...
http://mirrors.zimcom.net/pub/fedora/linux/updates/18/x86_64/repodata/repomd.xml: [Errno 14] curl#7 - "Failed to connect to 2607:f550:100:33::23: Network is unreachable"
Trying other mirror.
gpg: directory `/root/.gnupg' created
gpg: new configuration file `/root/.gnupg/gpg.conf' created
gpg: WARNING: options in `/root/.gnupg/gpg.conf' are not yet active during this run
gpg: keyring `/root/.gnupg/secring.gpg' created
gpg: keyring `/root/.gnupg/pubring.gpg' created
gpg: requesting key 4BD6EC30 from hkp server pool.sks-keyservers.net
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key 4BD6EC30: public key "Puppet Labs Release Key (Puppet Labs Release Key) <info@puppetlabs.com>" imported
gpg: no need for a trustdb check with `direct' trust model
gpg: Total number processed: 1
gpg:               imported: 1  (RSA: 1)
Installing puppetlabs GPG key
Puppet GPG key installed successfully
installing puppetlabs yum repository from https://yum.puppetlabs.com/fedora/f18/products/x86_64/puppetlabs-release-18-7.noarch.rpm
Puppetlabs yum repo installed sucessfully
installing ruby-devel and dependencies...
installing puppet and dependencies...
Verifying that puppet and facter installed successfully...
Detected puppet version 3.4.2
Detected facter version 1.7.4
Puppet and facter installed successfully
```
